### PR TITLE
Support IOCapture 1.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [compat]
-IOCapture = "0.2"
+IOCapture = "0.2, 1"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
It is fully backwards compatible with version 0.2.

Ping @mortenpi 